### PR TITLE
Refactor Zache#clean method to use key_expired? private method

### DIFF
--- a/lib/zache.rb
+++ b/lib/zache.rb
@@ -89,12 +89,12 @@ class Zache
     if @sync
       @mutex.synchronize do
         @hash.delete_if do |_key, value|
-          value[:start] < Time.now - value[:lifetime]
+          key_expired?(value)
         end
       end
     else
       @hash.delete_if do |_key, value|
-        value[:start] < Time.now - value[:lifetime]
+        key_expired?(value)
       end
     end
   end


### PR DESCRIPTION
@yegor256 ive refactored Zache#clean method so it uses recently created key_expired? method