### PR TITLE
Do not sleep in synchronize block

### DIFF
--- a/lib/zache.rb
+++ b/lib/zache.rb
@@ -195,17 +195,11 @@ class Zache
     @hash[key][:value]
   end
 
-  def synchronized
+  def synchronized(&block)
     if @sync
-      @mutex.synchronize do
-        # I don't know why, but if you remove this line, the tests will
-        # break. It seems to me that there is a bug in Ruby. Let's try to
-        # fix it or find a workaround and remove this line.
-        sleep 0.00001
-        yield
-      end
+      @mutex.synchronize(&block)
     else
-      yield
+      block.call
     end
   end
 end

--- a/test/test_zache.rb
+++ b/test/test_zache.rb
@@ -254,7 +254,9 @@ class ZacheTest < Minitest::Test
     cache = Zache.new(dirty: true)
     set = Concurrent::Set.new
     threads = 50
+    barrier = Concurrent::CyclicBarrier.new(threads)
     Threads.new(threads).assert(threads * 2) do |i|
+      barrier.wait if i < threads
       set << cache.get(i, lifetime: 0.001) { i }
     end
     assert_equal(threads, set.size)
@@ -264,7 +266,9 @@ class ZacheTest < Minitest::Test
     cache = Zache.new
     set = Concurrent::Set.new
     threads = 50
+    barrier = Concurrent::CyclicBarrier.new(threads)
     Threads.new(threads).assert(threads * 2) do |i|
+      barrier.wait if i < threads
       set << cache.get(i) { i }
     end
     assert_equal(threads, set.size)


### PR DESCRIPTION
The clue of the issue really was [that line](https://github.com/yegor256/threads/blob/6b22069aa66a7389eb6fd224135e626e36aed614/lib/threads.rb#L55)

As a single thread can increment rep multiple times, a thread can finish before ever calling `yield`. In the tests it is assumed otherwise.

One can imagine scenario with a ThreadPool of size 2, ThreadPool threads called T1 and T2,  `reps` = X

1. T1 waits [here](https://github.com/yegor256/threads/blob/6b22069aa66a7389eb6fd224135e626e36aed614/lib/threads.rb#L52)
2. T2 waits [here](https://github.com/yegor256/threads/blob/6b22069aa66a7389eb6fd224135e626e36aed614/lib/threads.rb#L52)
3. [This line](https://github.com/yegor256/threads/blob/6b22069aa66a7389eb6fd224135e626e36aed614/lib/threads.rb#L66) is called.
4. T1 gets woken up, increments `rep` counter X times(and also `yield` X times) and finishes.
5. T2 gets woken up and breaks from the loop immediately [here](https://github.com/yegor256/threads/blob/6b22069aa66a7389eb6fd224135e626e36aed614/lib/threads.rb#L55) before ever yielding, and then it finishes.

I used CyclicBarrier to make sure that all threads have a chance to yield before, making every thread wait for a barrier before incrementing `rep` counter more than once.

Of course this could also be resolved in https://github.com/yegor256/threads, but I have no idea whether this "all threads will yield at least once" guarantee is wanted in that library.

