### PR TITLE
feature: add total cache size

### DIFF
--- a/lib/zache.rb
+++ b/lib/zache.rb
@@ -48,6 +48,12 @@ class Zache
       false
     end
 
+    # Returns a fixed size of 0.
+    # @return [Integer] Always returns 0
+    def bytesize
+      0
+    end
+
     # No-op method that ignores the input.
     # @return [nil] Always returns nil
     def put(*); end
@@ -84,6 +90,7 @@ class Zache
     @dirty = dirty
     @mutex = Mutex.new
     @locks = {}
+    @bytesize = 0
   end
 
   # Total number of keys currently in cache.
@@ -91,6 +98,14 @@ class Zache
   # @return [Integer] Number of keys in the cache
   def size
     sync { @hash.size }
+  end
+
+  # Total bytesize of all values currently in cache. Maintained
+  # incrementally on every write/remove, so this is O(1).
+  #
+  # @return [Integer] Sum of the bytesize of all cached values
+  def bytesize
+    sync { @bytesize }
   end
 
   # Gets the value from the cache by the provided key.
@@ -177,9 +192,7 @@ class Zache
   # @param lifetime [Integer] Time in seconds until the key expires (default: never expires)
   # @return [Object] The value stored
   def put(key, value, lifetime: 2**32)
-    lock(key) do
-      @hash[key] = { value: value, start: Time.now, lifetime: lifetime }
-    end
+    lock(key) { write(key, value, lifetime) }
   end
 
   # Removes the value from the cache, by the provided key. If the key is absent
@@ -189,7 +202,10 @@ class Zache
   # @yield Block to call if the key is not found
   # @return [Object] The removed value or the result of the block
   def remove(key)
-    lock(key) { @hash.delete(key) { yield if block_given? } }
+    lock(key) do
+      rec = @hash.delete(key) { yield if block_given? }
+      @bytesize -= rec[:bytesize] if rec.is_a?(Hash) && rec[:bytesize]
+    end
     sync { @locks.delete(key) }
   end
 
@@ -200,6 +216,7 @@ class Zache
     sync do
       @hash = {}
       @locks = {}
+      @bytesize = 0
     end
   end
 
@@ -211,12 +228,15 @@ class Zache
   def remove_by
     sync do
       count = 0
+      freed = 0
       @hash.each_key do |k|
         next unless yield(k)
+        freed += @hash[k][:bytesize]
         @hash.delete(k)
         @locks.delete(k)
         count += 1
       end
+      @bytesize -= freed
       count
     end
   end
@@ -228,14 +248,17 @@ class Zache
   def clean
     sync do
       count = 0
-      @hash.delete_if do |key, _value|
+      freed = 0
+      @hash.delete_if do |key, rec|
         expired = overdue?(key)
         if expired
+          freed += rec[:bytesize]
           @locks.delete(key)
           count += 1
         end
         expired
       end
+      @bytesize -= freed
       count
     end
   end
@@ -303,7 +326,8 @@ class Zache
   # @param key [Object] The key to clean up
   def cleanup(key)
     sync do
-      @hash.delete(key)
+      rec = @hash.delete(key)
+      @bytesize -= rec[:bytesize] if rec
       @locks.delete(key)
     end
   end
@@ -333,11 +357,23 @@ class Zache
   def calc(key, lifetime)
     rec = @hash[key]
     rec = nil if overdue?(key)
-    if rec.nil?
-      rec = { value: yield, start: Time.now, lifetime: lifetime }
-      @hash[key] = rec
-    end
+    rec = write(key, yield, lifetime) if rec.nil?
     rec[:value]
+  end
+
+  # Stores a value under the given key, keeping @bytesize in sync with
+  # whatever was there before (if anything).
+  # @param key [Object] The key to store the value under
+  # @param value [Object] The value to store
+  # @param lifetime [Integer] Time in seconds until the key expires
+  # @return [Hash] The newly stored record
+  def write(key, value, lifetime)
+    size = value.respond_to?(:bytesize) ? value.bytesize : value.to_s.bytesize
+    old = @hash[key]
+    rec = { value: value, start: Time.now, lifetime: lifetime, bytesize: size }
+    @hash[key] = rec
+    sync { @bytesize += size - (old ? old[:bytesize] : 0) }
+    rec
   end
 
   # Internal method that checks if a key is expired without acquiring locks.

--- a/test/test_zache.rb
+++ b/test/test_zache.rb
@@ -118,6 +118,31 @@ class ZacheTest < Minitest::Test
     refute(z.exists?(:bye))
   end
 
+  def test_bytesize_increases_on_put
+    z = Zache.new
+    assert_equal(0, z.bytesize)
+    z.put(:hey, 'abc')
+    assert_equal(3, z.bytesize)
+    z.put(:bye, 'de')
+    assert_equal(5, z.bytesize)
+  end
+
+  def test_bytesize_decreases_on_remove
+    z = Zache.new
+    z.put(:hey, 'abc')
+    z.put(:bye, 'de')
+    z.remove(:hey)
+    assert_equal(2, z.bytesize)
+  end
+
+  def test_bytesize_is_zero_after_clean
+    z = Zache.new
+    z.put(:hey, 'abc', lifetime: 0.01)
+    sleep(0.1)
+    z.clean
+    assert_equal(0, z.bytesize)
+  end
+
   def test_clean_size
     z = Zache.new
     z.get(:hey, lifetime: 0.01) { rand }


### PR DESCRIPTION
👋🏻 hey

we are using zache on one of our apps and we are trying to track down why some pods are restarting. It appears to be linked to the cache size

<img width="612" height="296" alt="image" src="https://github.com/user-attachments/assets/e911a993-a6ee-42f2-b5e0-a8b083682ed6" />

in some pods, the memory grows until kubernetes kicks in and OOMs it or restarts it, but the thing is that we also track the total cached items and we found no correlation: these pods in the graph have maybe 50 to 100 items cached while pods that sits under 200mb of usage have 300 to 400 items.

Our suspicion is that some specific pods are caching big items. For that, we would need to also calculate and track the total bytesize of cached items

